### PR TITLE
Spring MVC support

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,6 +7,5 @@
 	<classpathentry kind="src" path="swagger-doclet-sample-jersey2/src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
-	<classpathentry kind="lib" path="/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home/lib/tools.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -7,5 +7,6 @@
 	<classpathentry kind="src" path="swagger-doclet-sample-jersey2/src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
+    <classpathentry kind="lib" path="/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home/lib/tools.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 target
 .DS_Store
 .idea/
+.settings/org.eclipse.m2e.core.prefs
+.settings/org.testng.eclipse.maven.prefs

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The 1.0.7 version corresponds to the carma 1.0.6 version.
 
 **Note from 1.1.3 and 1.0.7 the package and group id have changed from com.carma to com.tenxerconsulting.**
 
+The 1.1.4 contains these enhancements:
+
++ Support for Spring MVC annotations
+
 The 1.1.2 (and 1.0.6) versions contained these fixes:
 
 + Support annotations for excluding fields/classes/operations (Issue 134)

--- a/swagger-doclet-sample-jersey2/.gitignore
+++ b/swagger-doclet-sample-jersey2/.gitignore
@@ -1,1 +1,4 @@
 /dependency-reduced-pom.xml
+.classpath
+.project
+.settings/

--- a/swagger-doclet/.gitignore
+++ b/swagger-doclet/.gitignore
@@ -1,3 +1,4 @@
 .classpath
 .project
 .settings/
+src/test/java/com/tenxerconsulting/swagger/doclet/DocletRunner.java

--- a/swagger-doclet/.gitignore
+++ b/swagger-doclet/.gitignore
@@ -1,4 +1,3 @@
-/dependency-reduced-pom.xml
 .classpath
 .project
 .settings/

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/model/HttpMethod.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/model/HttpMethod.java
@@ -2,7 +2,6 @@ package com.tenxerconsulting.swagger.doclet.model;
 
 import java.util.List;
 
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.parser.Parser;
 import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ExecutableMemberDoc;
 import com.tenxerconsulting.swagger.doclet.DocletOptions;

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/model/HttpMethod.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/model/HttpMethod.java
@@ -1,31 +1,40 @@
 package com.tenxerconsulting.swagger.doclet.model;
 
+import java.util.List;
+
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.parser.Parser;
 import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ExecutableMemberDoc;
+import com.tenxerconsulting.swagger.doclet.DocletOptions;
+import com.tenxerconsulting.swagger.doclet.parser.ParserHelper;
 
 public enum HttpMethod {
 
-	GET("javax.ws.rs.GET"),
-	PUT("javax.ws.rs.PUT"),
-	POST("javax.ws.rs.POST"),
-	DELETE("javax.ws.rs.DELETE"),
-	HEAD("javax.ws.rs.HEAD"),
-	OPTIONS("javax.ws.rs.OPTIONS"),
-	PATCH(".PATCH", true);
+    // JAX-RS
+	GET("javax.ws.rs.GET", "org.springframework.web.bind.annotation.RequestMethod.GET"),
+	PUT("javax.ws.rs.PUT", "org.springframework.web.bind.annotation.RequestMethod.PUT"),
+	POST("javax.ws.rs.POST", "org.springframework.web.bind.annotation.RequestMethod.POST"),
+	DELETE("javax.ws.rs.DELETE", "org.springframework.web.bind.annotation.RequestMethod.DELETE"),
+	HEAD("javax.ws.rs.HEAD", "org.springframework.web.bind.annotation.RequestMethod.HEAD"),
+	OPTIONS("javax.ws.rs.OPTIONS", "org.springframework.web.bind.annotation.RequestMethod.OPTIONS"),
+    PATCH(".PATCH", ".PATCH", true);
 
 	// NOTE Patch is not part of JAXRS 1 or 2 as it stands (people can add it but it will have an arbitrary package)
 	// so we will look for any annotation ending in .PATCH
 
 	private final String className;
+	private final String springMvcClassName;
 	private final boolean useContains;
 
-	private HttpMethod(String className) {
+	private HttpMethod(String className, String springMvcClassName) {
 		this.className = className;
+		this.springMvcClassName = springMvcClassName;
 		this.useContains = false;
 	}
 
-	private HttpMethod(String className, boolean useContains) {
+	private HttpMethod(String className, String springMvcClassName, boolean useContains) {
 		this.className = className;
+        this.springMvcClassName = springMvcClassName;
 		this.useContains = useContains;
 	}
 
@@ -34,9 +43,10 @@ public enum HttpMethod {
 	 * @param method The java method to check
 	 * @return The HTTP method or null if there is not HTTP method annotation on the java method
 	 */
-	public static HttpMethod fromMethod(ExecutableMemberDoc method) {
+	public static HttpMethod fromMethod(ExecutableMemberDoc method, DocletOptions options) {
 		for (AnnotationDesc annotation : method.annotations()) {
 			String qName = annotation.annotationType().qualifiedTypeName();
+			
 			for (HttpMethod value : HttpMethod.values()) {
 				if (value.useContains && qName.contains(value.className)) {
 					return value;
@@ -44,7 +54,29 @@ public enum HttpMethod {
 					return value;
 				}
 			}
+			
+			if (qName.equals("org.springframework.web.bind.annotation.RequestMapping")) {
+			    List<String> methods = ParserHelper.listInheritableValues(method, ParserHelper.SPRING_MVC_REQUEST_MAPPING, "method", options);
+			    
+			    if (methods == null) {
+			        methods = ParserHelper.listValues(method.containingClass(), ParserHelper.SPRING_MVC_REQUEST_MAPPING, "method", options);   
+			    }
+			    
+			    if (methods != null && methods.size() > 0) {
+			        // FIXME: Spring MVC supports multile methods
+			        String m = methods.get(0);
+			    
+		            for (HttpMethod value : HttpMethod.values()) {
+		                if (value.useContains && m.contains(value.springMvcClassName)) {
+		                    return value;
+		                } else if (!value.useContains && m.equals(value.springMvcClassName)) {
+		                    return value;
+		                }
+		            }
+			    }
+			}
 		}
+		
 		return null;
 	}
 }

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/AnnotationParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/AnnotationParser.java
@@ -128,30 +128,32 @@ public class AnnotationParser {
 	/**
 	 * This gets the values of an annotation as strings
 	 * @param qualifiedAnnotationType The FQN of the annotation
-	 * @param key The field name of the annotation to get
+     * @param keys The name of the attribute(s) of the annotation to get the value of
 	 * @return The values or null if none were found
 	 */
-	public String[] getAnnotationValues(String qualifiedAnnotationType, String key) {
+	public String[] getAnnotationValues(String qualifiedAnnotationType, String... keys) {
 		AnnotationDesc annotation = getAnnotation(qualifiedAnnotationType, false);
 		if (annotation == null) {
 			return null;
 		}
 		for (AnnotationDesc.ElementValuePair evp : annotation.elementValues()) {
-			if (evp.element().name().equals(key)) {
-				Object val = evp.value().value();
-				AnnotationValue[] vals = (AnnotationValue[]) val;
-				if (vals != null && vals.length > 0) {
-					String[] res = new String[vals.length];
-					int i = 0;
-					for (AnnotationValue annotationVal : vals) {
-						String str = annotationVal.value().toString().trim();
-						str = this.options.replaceVars(str);
-						res[i] = str;
-						i++;
-					}
-					return res;
-				}
-			}
+            for (String key : keys) {
+    			if (evp.element().name().equals(key)) {
+    				Object val = evp.value().value();
+    				AnnotationValue[] vals = (AnnotationValue[]) val;
+    				if (vals != null && vals.length > 0) {
+    					String[] res = new String[vals.length];
+    					int i = 0;
+    					for (AnnotationValue annotationVal : vals) {
+    						String str = annotationVal.value().toString().trim();
+    						str = this.options.replaceVars(str);
+    						res[i] = str;
+    						i++;
+    					}
+    					return res;
+    				}
+    			}
+            }
 		}
 		return null;
 	}

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
@@ -71,7 +71,7 @@ public class ApiMethodParser {
 		this.parentPath = parentPath;
 		this.methodDoc = methodDoc;
 		this.models = new LinkedHashSet<>();
-		this.httpMethod = ParserHelper.resolveMethodHttpMethod(methodDoc);
+		this.httpMethod = ParserHelper.resolveMethodHttpMethod(methodDoc, options);
 		this.parentMethod = null;
 		this.classDefaultErrorType = classDefaultErrorType;
 		this.methodDefaultErrorType = ParserHelper.getInheritableTagValue(methodDoc, options.getDefaultErrorTypeTags(), options);
@@ -744,10 +744,15 @@ public class ApiMethodParser {
 			return false;
 		}
 
-		// include if it has a jaxrs annotation
-		if (ParserHelper.hasJaxRsAnnotation(parameter, this.options)) {
-			return true;
-		}
+        // include if it has a jaxrs annotation
+        if (ParserHelper.hasJaxRsAnnotation(parameter, this.options)) {
+            return true;
+        }
+
+        // include if it has a jaxrs annotation
+        if (ParserHelper.hasSpringMvcAnnotation(parameter, this.options)) {
+            return true;
+        }
 
 		// include if there are either no annotations or its a put/post/patch
 		// this means for GET/HEAD/OPTIONS we don't include if it has some non jaxrs annotation on it

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
@@ -749,7 +749,7 @@ public class ApiMethodParser {
             return true;
         }
 
-        // include if it has a jaxrs annotation
+        // include if it has a Spring MVC annotation
         if (ParserHelper.hasSpringMvcAnnotation(parameter, this.options)) {
             return true;
         }

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/CrossClassApiParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/CrossClassApiParser.java
@@ -122,7 +122,7 @@ public class CrossClassApiParser {
         if (this.rootPath.isEmpty()) {
             boolean methodFound = false;
             for (MethodDoc method : this.classDoc.methods()) {
-                if (ParserHelper.resolveMethodHttpMethod(method) != null) {
+                if (ParserHelper.resolveMethodHttpMethod(method, options) != null) {
                     methodFound = true;
                     break;
                 }

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
@@ -157,7 +157,7 @@ public class JaxRsAnnotationParser {
 
                     for (MethodDoc method : currentClassDoc.methods()) {
                         // if the method has @Path but no Http method then its an entry point to a sub resource
-                        if (!ParserHelper.resolveMethodPath(method, this.options).isEmpty() && HttpMethod.fromMethod(method) == null) {
+                        if (!ParserHelper.resolveMethodPath(method, this.options).isEmpty() && HttpMethod.fromMethod(method, options) == null) {
                             ClassDoc subResourceClassDoc = classCache.findByType(method.returnType());
                             // look for a custom return type, this is useful where we return a jaxrs Resource in the method signature
                             // which typically returns a different subResource object

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -775,9 +775,7 @@ public class ParserHelper {
         try {
             Class<?> clazz = lookupClass(javaType);
             boolean res = java.util.Collection.class.isAssignableFrom(clazz);
-//            if (res) {
-                COLLECTION_TYPES.put(javaType, res);
-//            }
+            COLLECTION_TYPES.put(javaType, res);
             return res;
         } catch (ClassNotFoundException ex) {
             return false;
@@ -799,9 +797,7 @@ public class ParserHelper {
         try {
             Class<?> clazz = lookupClass(javaType);
             boolean res = java.util.Map.class.isAssignableFrom(clazz);
-//            if (res) {
-                MAP_TYPES.put(javaType, res);
-//            }
+            MAP_TYPES.put(javaType, res);
             return res;
         } catch (ClassNotFoundException ex) {
             return false;
@@ -861,15 +857,11 @@ public class ParserHelper {
      */
     public static String paramTypeOf(boolean returnDefault, boolean multipart, ProgramElementDoc paramMember, Type type, DocletOptions options) {
         AnnotationParser p = new AnnotationParser(paramMember, options);
-        if (p.isAnnotatedBy(JAX_RS_PATH_PARAM)) {
-            return "path";
-        } else if (p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) {
+        if (p.isAnnotatedBy(JAX_RS_PATH_PARAM) || p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) {
             return "path";
         } else if (p.isAnnotatedBy(JAX_RS_HEADER_PARAM)) {
             return "header";
-        } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM)) {
-            return "query";
-        } else if (p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
+        } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM) || p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
             return "query";
         } else if (p.isAnnotatedBy(JAX_RS_FORM_PARAM)) {
             return "form";
@@ -925,15 +917,11 @@ public class ParserHelper {
      */
     public static String paramTypeOf(boolean multipart, Parameter parameter, DocletOptions options) {
         AnnotationParser p = new AnnotationParser(parameter, options);
-        if (p.isAnnotatedBy(JAX_RS_PATH_PARAM)) {
-            return "path";
-        } else if (p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) { 
+        if (p.isAnnotatedBy(JAX_RS_PATH_PARAM) || p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) {
             return "path";
         } else if (p.isAnnotatedBy(JAX_RS_HEADER_PARAM)) {
             return "header";
-        } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM)) {
-            return "query";
-        } else if (p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
+        } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM) || p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
             return "query";
         } else if (p.isAnnotatedBy(JAX_RS_FORM_PARAM)) {
             return "form";

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.collect.Lists.transform;
 import static java.util.Arrays.asList;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,7 +28,6 @@ import com.sun.javadoc.Type;
 import com.sun.javadoc.TypeVariable;
 import com.tenxerconsulting.swagger.doclet.DocletOptions;
 import com.tenxerconsulting.swagger.doclet.model.HttpMethod;
-import io.swagger.models.parameters.*;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.PropertyBuilder;
 import io.swagger.models.properties.RefProperty;
@@ -46,6 +44,9 @@ public class ParserHelper {
     private static final String JAX_RS_QUERY_PARAM = "javax.ws.rs.QueryParam";
     private static final String JAX_RS_HEADER_PARAM = "javax.ws.rs.HeaderParam";
     private static final String JAX_RS_FORM_PARAM = "javax.ws.rs.FormParam";
+    
+    private static final String SPRING_MVC_PATH_VARIABLE = "org.springframework.web.bind.annotation.PathVariable";
+    private static final String SPRING_MVC_REQUEST_PARAM = "org.springframework.web.bind.annotation.RequestParam";
 
     private static final Set<String> _JAXRS_PARAM_ANNOTATIONS = new HashSet<String>();
 
@@ -55,6 +56,9 @@ public class ParserHelper {
         _JAXRS_PARAM_ANNOTATIONS.add(JAX_RS_QUERY_PARAM);
         _JAXRS_PARAM_ANNOTATIONS.add(JAX_RS_HEADER_PARAM);
         _JAXRS_PARAM_ANNOTATIONS.add(JAX_RS_FORM_PARAM);
+        
+        _JAXRS_PARAM_ANNOTATIONS.add(SPRING_MVC_PATH_VARIABLE);
+        _JAXRS_PARAM_ANNOTATIONS.add(SPRING_MVC_REQUEST_PARAM);
     }
 
     /**
@@ -63,13 +67,19 @@ public class ParserHelper {
     public static final Set<String> JAXRS_PARAM_ANNOTATIONS = Collections.unmodifiableSet(_JAXRS_PARAM_ANNOTATIONS);
 
     private static final String JAX_RS_ANNOTATION_PACKAGE = "javax.ws.rs";
+    private static final String SPRING_MVC_ANNOTATION_PACKAGE = "org.springframework.web.bind.annotation";
+
     private static final Set<String> JAX_RS_PREFIXES = new HashSet<String>();
+    private static final Set<String> SPRING_MVC_PREFIXES = new HashSet<String>();
 
     static {
         JAX_RS_PREFIXES.add(JAX_RS_ANNOTATION_PACKAGE);
+        SPRING_MVC_PREFIXES.add(SPRING_MVC_ANNOTATION_PACKAGE);
     }
 
     private static final String JAX_RS_PATH = "javax.ws.rs.Path";
+    
+    public static final String SPRING_MVC_REQUEST_MAPPING = "org.springframework.web.bind.annotation.RequestMapping";
 
     private static final String JAX_RS_CONSUMES = "javax.ws.rs.Consumes";
     private static final String JAX_RS_PRODUCES = "javax.ws.rs.Produces";
@@ -163,6 +173,35 @@ public class ParserHelper {
         }
         return null;
     }
+    
+    /**
+     * This gets an annotation value array from the given class, it supports looking at super classes
+     * @param classDoc The class to look for the annotation
+     * @param options The doclet options
+     * @param qualifiedAnnotationType The FQN of the annotation to look for
+     * @param keys The keys for the annotation values
+     * @return The value of the annotation or null if none was found
+     */
+    public static String[] getInheritableClassLevelAnnotationValues(ClassDoc classDoc, DocletOptions options, String qualifiedAnnotationType, String... keys) {
+        ClassDoc currentClassDoc = classDoc;
+        while (currentClassDoc != null) {
+
+            AnnotationParser p = new AnnotationParser(currentClassDoc, options);
+            String[] values = p.getAnnotationValues(qualifiedAnnotationType, keys);
+
+            if (values != null) {
+                return values;
+            }
+
+            currentClassDoc = currentClassDoc.superclass();
+            // ignore parent object class
+            if (!ParserHelper.hasAncestor(currentClassDoc)) {
+                break;
+            }
+        }
+        return null;
+    }
+   
 
     /**
      * This gets the default value of the given parameter
@@ -174,11 +213,16 @@ public class ParserHelper {
     public static String getDefaultValue(Parameter param, DocletOptions options) {
         AnnotationParser p = new AnnotationParser(param, options);
         String value = p.getAnnotationValue(JAX_RS_DEFAULT_VALUE, "value");
+        
+        if (value == null) {
+            value = p.getAnnotationValue(SPRING_MVC_REQUEST_PARAM, "defaultValue");
+        }
+        
         return value;
     }
 
     /**
-     * Resolves the @Path for the ClassDoc supporting inheritance
+     * Resolves the @Path or @ResourceMapping for the ClassDoc supporting inheritance
      *
      * @param classDoc The class to be processed
      * @param options  Doclet options
@@ -186,6 +230,16 @@ public class ParserHelper {
      */
     public static String resolveClassPath(ClassDoc classDoc, DocletOptions options) {
         String path = ParserHelper.getInheritableClassLevelAnnotationValue(classDoc, options, JAX_RS_PATH, "value");
+        
+        if (path == null) {
+            String[] paths = ParserHelper.getInheritableClassLevelAnnotationValues(classDoc, options, SPRING_MVC_REQUEST_MAPPING, "path", "value");
+            
+            if (paths != null && paths.length > 0) {
+                // FIXME Spring MVC supports multiple paths for one resource
+                path = paths[0];
+            }
+        }
+        
         return normalisePath(path);
     }
 
@@ -202,6 +256,15 @@ public class ParserHelper {
         while (path == null && methodDoc != null) {
             AnnotationParser p = new AnnotationParser(methodDoc, options);
             path = p.getAnnotationValue(JAX_RS_PATH, "value");
+            
+            if (path == null) {
+                String[] paths = p.getAnnotationValues(SPRING_MVC_REQUEST_MAPPING, "path", "value");
+                
+                if (paths != null && paths.length > 0) {
+                    // FIXME Spring MVC supports multiple paths for one resource
+                    path = paths[0];
+                }
+            }
             methodDoc = getAncestorMethod(methodDoc);
         }
         return normalisePath(path);
@@ -800,9 +863,13 @@ public class ParserHelper {
         AnnotationParser p = new AnnotationParser(paramMember, options);
         if (p.isAnnotatedBy(JAX_RS_PATH_PARAM)) {
             return "path";
+        } else if (p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) {
+            return "path";
         } else if (p.isAnnotatedBy(JAX_RS_HEADER_PARAM)) {
             return "header";
         } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM)) {
+            return "query";
+        } else if (p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
             return "query";
         } else if (p.isAnnotatedBy(JAX_RS_FORM_PARAM)) {
             return "form";
@@ -860,9 +927,13 @@ public class ParserHelper {
         AnnotationParser p = new AnnotationParser(parameter, options);
         if (p.isAnnotatedBy(JAX_RS_PATH_PARAM)) {
             return "path";
+        } else if (p.isAnnotatedBy(SPRING_MVC_PATH_VARIABLE)) { 
+            return "path";
         } else if (p.isAnnotatedBy(JAX_RS_HEADER_PARAM)) {
             return "header";
         } else if (p.isAnnotatedBy(JAX_RS_QUERY_PARAM)) {
+            return "query";
+        } else if (p.isAnnotatedBy(SPRING_MVC_REQUEST_PARAM)) {
             return "query";
         } else if (p.isAnnotatedBy(JAX_RS_FORM_PARAM)) {
             return "form";
@@ -1105,10 +1176,21 @@ public class ParserHelper {
      */
     public static List<String> getConsumes(MethodDoc methodDoc, DocletOptions options) {
         List<String> methodLevel = listInheritableValues(methodDoc, JAX_RS_CONSUMES, "value", options);
+        
+        if (methodLevel == null) {
+            methodLevel = listInheritableValues(methodDoc, SPRING_MVC_REQUEST_MAPPING, "consumes", options);
+        }
+        
         if (methodLevel == null) {
             // look for class level
-            return listValues(methodDoc.containingClass(), JAX_RS_CONSUMES, "value", options);
+            methodLevel = listValues(methodDoc.containingClass(), JAX_RS_CONSUMES, "value", options);
         }
+        
+        if (methodLevel == null) {
+            // look for class level
+            methodLevel = listValues(methodDoc.containingClass(), SPRING_MVC_REQUEST_MAPPING, "consumes", options);
+        }
+        
         return methodLevel;
     }
 
@@ -1121,10 +1203,21 @@ public class ParserHelper {
      */
     public static List<String> getProduces(MethodDoc methodDoc, DocletOptions options) {
         List<String> methodLevel = listInheritableValues(methodDoc, JAX_RS_PRODUCES, "value", options);
+        
+        if (methodLevel == null) {
+            methodLevel = listInheritableValues(methodDoc, SPRING_MVC_REQUEST_MAPPING, "produces", options);
+        }
+        
         if (methodLevel == null) {
             // look for class level
-            return listValues(methodDoc.containingClass(), JAX_RS_PRODUCES, "value", options);
+            methodLevel = listValues(methodDoc.containingClass(), JAX_RS_PRODUCES, "value", options);
         }
+
+        if (methodLevel == null) {
+            // look for class level
+            methodLevel = listValues(methodDoc.containingClass(), SPRING_MVC_REQUEST_MAPPING, "produces", options);
+        }
+
         return methodLevel;
     }
 
@@ -1613,12 +1706,13 @@ public class ParserHelper {
      * Resolves HttpMethod for the MethodDoc respecting the overriden methods
      *
      * @param methodDoc The method to be processed
+     * @param options The options
      * @return The resolved HttpMethod
      */
-    public static HttpMethod resolveMethodHttpMethod(ExecutableMemberDoc methodDoc) {
+    public static HttpMethod resolveMethodHttpMethod(ExecutableMemberDoc methodDoc, DocletOptions options) {
         HttpMethod result = null;
         while (result == null && methodDoc != null) {
-            result = HttpMethod.fromMethod(methodDoc);
+            result = HttpMethod.fromMethod(methodDoc, options);
             methodDoc = getAncestorMethod(methodDoc);
         }
         return result;
@@ -1950,6 +2044,17 @@ public class ParserHelper {
      */
     public static boolean hasJaxRsAnnotation(Parameter item, DocletOptions options) {
         return hasAnnotationWithPrefix(item, JAX_RS_PREFIXES, options);
+    }
+
+    /**
+     * This gets whether the given parameter has a Sping MVC annotation
+     *
+     * @param item    The parameter
+     * @param options The doclet options
+     * @return True if the parameter has the given annotation
+     */
+    public static boolean hasSpringMvcAnnotation(Parameter item, DocletOptions options) {
+        return hasAnnotationWithPrefix(item, SPRING_MVC_PREFIXES, options);
     }
 
     /**

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -760,7 +760,7 @@ public class ParserHelper {
         return (javaType.equals("array") || javaType.endsWith("[]"));
     }
 
-    private static Map<String, Boolean> COLLECTION_TYPES = new HashMap<String, Boolean>();
+    private static final Map<String, Boolean> COLLECTION_TYPES = new HashMap<String, Boolean>();
 
     /**
      * This gets whether the given type is a Collection
@@ -775,16 +775,16 @@ public class ParserHelper {
         try {
             Class<?> clazz = lookupClass(javaType);
             boolean res = java.util.Collection.class.isAssignableFrom(clazz);
-            if (res) {
+//            if (res) {
                 COLLECTION_TYPES.put(javaType, res);
-            }
+//            }
             return res;
         } catch (ClassNotFoundException ex) {
             return false;
         }
     }
 
-    private static Map<String, Boolean> MAP_TYPES = new HashMap<String, Boolean>();
+    private static final Map<String, Boolean> MAP_TYPES = new HashMap<String, Boolean>();
 
     /**
      * This gets whether the given type is a Map
@@ -799,9 +799,9 @@ public class ParserHelper {
         try {
             Class<?> clazz = lookupClass(javaType);
             boolean res = java.util.Map.class.isAssignableFrom(clazz);
-            if (res) {
+//            if (res) {
                 MAP_TYPES.put(javaType, res);
-            }
+//            }
             return res;
         } catch (ClassNotFoundException ex) {
             return false;


### PR DESCRIPTION
Hi,

I have added support for [Spring MVC](https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html) annotations following [this chart](https://gokan-ekinci.appspot.com/en/articles/java/rest-restful-spring-mvc-jax-rs-comparison)). As you can see there is  (mostly) a 1:1 relation between the annotations. The implementation is fully compatible, it just checks some additional classnames. I would be very happy if you could integrate these changes to your fork. Unfortunately the tests did not work, even before making any changes to the code. 

LG, Manfred